### PR TITLE
added temporary fix for coloring icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "lottie-web": "^5.5.7",
-    "react-highlight.js": "^1.0.7"
+    "react-highlight.js": "^1.0.7",
+    "styled-components": "4.4.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.2",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import lottie from 'lottie-web';
+import styled from 'styled-components';
 import { getEffect, getAnimationData, getEvents, LOOP_PLAY } from './utils';
+
+const ColoredIcon = styled.div`
+  path {
+    stroke: ${({ strokeColor }) => strokeColor};
+  }
+`;
 
 export default class UseAnimations extends React.Component {
   state = {
@@ -35,7 +42,7 @@ export default class UseAnimations extends React.Component {
   setAnimation = animation => this.setState({ animation });
 
   render() {
-    const { animationKey, size, style, ...other } = this.props;
+    const { animationKey, size, style, strokeColor, ...other } = this.props;
     const { animation } = this.state;
 
     const defaultStyles = {
@@ -55,7 +62,7 @@ export default class UseAnimations extends React.Component {
       }),
     };
 
-    return <div {...animationProps} />;
+    return <ColoredIcon {...animationProps} strokeColor={strokeColor} />;
   }
 }
 


### PR DESCRIPTION
Noticed in a thread that you need to redo all the icons to properly support coloring of the icons, thought this might suffice as a temporary solution. Just need to think about how you want the user to color the icons, I've added a prop strokeColor to pass this through but could be refactored to get this from the style prop.