### PR TITLE
[Feat] `lottie`: add speed props

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ These props are available:
 |  autoplay | `false`* | false except in animations like loading etc. |
 |  loop | `false`* | false except in animations like loading etc. |
 |  options | `{}` | provide any other custom options which will override the default ones |
+|  speed | 1 | a number to determine the speed of lottie(1 is normal speed) |
 
 <br />
 Controlled checkbox example  

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ These props are available:
 |  autoplay | `false`* | false except in animations like loading etc. |
 |  loop | `false`* | false except in animations like loading etc. |
 |  options | `{}` | provide any other custom options which will override the default ones |
-|  speed | 1 | a number to determine the speed of lottie(1 is normal speed) |
+|  speed | `1` | a number to determine the speed of lottie(1 is normal speed) |
 
 <br />
 Controlled checkbox example  

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,6 +19,7 @@ type Props = {
   size?: number;
   loop?: AnimationConfig['loop'];
   autoplay?: AnimationConfig['autoplay'];
+  speed?: number;
   wrapperStyle?: React.CSSProperties;
   render?: (eventProps: any, animationProps: any) => ReactElement;
 } & React.HTMLProps<HTMLDivElement>;
@@ -27,6 +28,7 @@ const UseAnimations: React.FC<Props> = ({
   animation: { animationData, animationKey },
   reverse = false,
   size = 24,
+  speed = 1,
   strokeColor,
   pathCss,
   loop,
@@ -112,6 +114,12 @@ const UseAnimations: React.FC<Props> = ({
       }
     };
   }, []);
+
+  useEffect(()=> {
+    if (animation) {
+      animation.setSpeed(speed)
+    }
+  }, [animation, speed])
 
   const defaultStyles = {
     overflow: 'hidden',

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -119,7 +119,7 @@ const UseAnimations: React.FC<Props> = ({
     if (animation) {
       animation.setSpeed(speed)
     }
-  }, [animation, speed])
+  }, [animation, speed]);
 
   const defaultStyles = {
     overflow: 'hidden',


### PR DESCRIPTION
# Summary

As mentioned in [lottie web docs](http://airbnb.io/lottie/#/web), there is a setSpeed function that let us to set animation speed.
I think we should add this props and use it! 😄 

Thanks you so much for your code review!