### PR TITLE
Add React 17 and 18 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-useanimations",
-  "version": "2.0.8",
+  "name": "@ctessier/react-useanimations",
+  "version": "2.0.9",
   "description": "Official React component for useanimations icons",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,6 @@
     "typescript": "^3.8.3"
   },
   "peerDependencies": {
-    "react": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.0 || ^18.0.0"
   }
 }


### PR DESCRIPTION
This pull request add both React 17 and React 18 to the `peerDependencies`.